### PR TITLE
chore: fix typo in url

### DIFF
--- a/index.html
+++ b/index.html
@@ -237,7 +237,7 @@ done
       </p>
 
       <pre><code class='bash'>
-curl "https://patchbay.pub/pubsub/<span class='channel'>aa7cc811-d21c-42ef-92cc-a5566fa38344</span>method=post&body=Job%20Done"
+curl "https://patchbay.pub/pubsub/<span class='channel'>aa7cc811-d21c-42ef-92cc-a5566fa38344</span>?method=post&body=Job%20Done"
       </code></pre>
 
       <p>


### PR DESCRIPTION
URL was missing a `?` before query Paramus 